### PR TITLE
feat: Added currency symbol conversion (e.g. 'USD' to '$')

### DIFF
--- a/lib/components/SubscriptionsTable/SubscriptionsTable.tsx
+++ b/lib/components/SubscriptionsTable/SubscriptionsTable.tsx
@@ -1,7 +1,14 @@
 import React, { useState } from 'react'
 import MoreVertIcon from '@material-ui/icons/MoreVert'
 
-import { Button, IconButton, Menu, MenuItem, useTranslation } from '@apisuite/fe-base'
+import {
+  Button,
+  IconButton,
+  Menu,
+  MenuItem,
+  useTranslation,
+} from '@apisuite/fe-base'
+import { convertDate } from '../../util/convertDate'
 import { CustomizableDialog } from '../CustomizableDialog/CustomizableDialog'
 import { SubscriptionsTableProps } from './types'
 import useStyles from './styles'
@@ -41,16 +48,6 @@ const SubscriptionsTable: React.FC<SubscriptionsTableProps> = ({
     'Cancel subscription plan',
   ]
 
-  const convertDate = (dateString: string) => {
-    const dateFormat = new Intl.DateTimeFormat('en', {
-      year: 'numeric',
-      month: 'long',
-      day: '2-digit',
-    })
-
-    return dateFormat.format(new Date(dateString))
-  }
-
   const handleConfirmCancelSubscription = () => {
     setCancelSubDialogOpen(false)
     onCancelSubscription()
@@ -73,7 +70,9 @@ const SubscriptionsTable: React.FC<SubscriptionsTableProps> = ({
                 key={`subTableEntry${index}`}
               >
                 <td>{sub.subName}</td>
-                <td>{convertDate(sub.subNextBillingDate)}</td>
+                <td>
+                  {convertDate(trans.i18n.language, sub.subNextBillingDate)}
+                </td>
                 <td>
                   <IconButton onClick={handleMenuClick}>
                     <MoreVertIcon />

--- a/lib/components/TransactionsTable/TransactionsTable.tsx
+++ b/lib/components/TransactionsTable/TransactionsTable.tsx
@@ -30,6 +30,13 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
     return dateFormat.format(new Date(dateString))
   }
 
+  const currencyConverter = (valueString: string, currencyString: string) => {
+    return parseInt(valueString).toLocaleString(trans.i18n.language, {
+      style: 'currency',
+      currency: currencyString,
+    })
+  }
+
   const generateTransactionsTableEntries = () => {
     const arrayOfTableEntries = transactions.map((transaction, index) => {
       return (
@@ -79,7 +86,10 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
           </p>
 
           <p className={classes.transactionAmount}>
-            {`${transaction.transactionAmount.transactionCurrency} ${transaction.transactionAmount.transactionValue}`}
+            {currencyConverter(
+              transaction.transactionAmount.transactionValue,
+              transaction.transactionAmount.transactionCurrency
+            )}
           </p>
         </div>
       )
@@ -87,8 +97,6 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
 
     return arrayOfTableEntries
   }
-
-  // TODO: Convert 'EUR' references to '€'
 
   return (
     <div className={classes.transactionsTable}>

--- a/lib/components/TransactionsTable/TransactionsTable.tsx
+++ b/lib/components/TransactionsTable/TransactionsTable.tsx
@@ -6,6 +6,8 @@ import FileCopyRoundedIcon from '@material-ui/icons/FileCopyRounded'
 import { TransactionsTableProps } from './types'
 import { useTranslation } from '@apisuite/fe-base'
 import useStyles from './styles'
+import { convertDate } from '../../util/convertDate'
+import { currencyConverter } from '../../util/currencyConverter'
 
 const TransactionsTable: React.FC<TransactionsTableProps> = ({
   transactions,
@@ -16,25 +18,6 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
 
   const t = (str: string) => {
     return trans.t(`extensions.billing.${str}`)
-  }
-
-  const convertDate = (dateString: string) => {
-    const dateFormat = new Intl.DateTimeFormat(trans.i18n.language, {
-      year: 'numeric',
-      month: 'long',
-      day: '2-digit',
-      hour: '2-digit',
-      minute: '2-digit',
-    })
-
-    return dateFormat.format(new Date(dateString))
-  }
-
-  const currencyConverter = (valueString: string, currencyString: string) => {
-    return parseInt(valueString).toLocaleString(trans.i18n.language, {
-      style: 'currency',
-      currency: currencyString,
-    })
   }
 
   const generateTransactionsTableEntries = () => {
@@ -63,7 +46,7 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
           </div>
 
           <p className={classes.transactionDate}>
-            {convertDate(transaction.transactionDate)}
+            {convertDate(trans.i18n.language, transaction.transactionDate)}
           </p>
 
           <p
@@ -87,6 +70,7 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
 
           <p className={classes.transactionAmount}>
             {currencyConverter(
+              trans.i18n.language,
               transaction.transactionAmount.transactionValue,
               transaction.transactionAmount.transactionCurrency
             )}

--- a/lib/pages/Billing/Billing.tsx
+++ b/lib/pages/Billing/Billing.tsx
@@ -27,11 +27,11 @@ const Billing: React.FC<BillingProps> = ({
   user,
 }) => {
   const classes = useStyles()
-  const trans = useTranslation()
-  const [dialogOpen, setDialogOpen] = useState(false)
 
-  const t = (str: string, otherParameters?) => {
-    return trans.t(`extensions.billing.${str}`, otherParameters)
+  const trans = useTranslation()
+
+  const t = (str: string, ...args) => {
+    return trans.t(`extensions.billing.${str}`, ...args)
   }
 
   /* Triggers the retrieval and storage (on the app's Store, under 'billing')
@@ -43,12 +43,6 @@ const Billing: React.FC<BillingProps> = ({
     getAllUserDetailsAction(user.id)
     getAllUserTransactionsAction()
   }, [successfullySubscribedToPlan])
-
-  useEffect(() => {
-    if (dialogInfo.transKeys.title.length) {
-      setDialogOpen(true)
-    }
-  }, [dialogInfo.transKeys.title])
 
   /* Credits logic */
 
@@ -143,15 +137,6 @@ const Billing: React.FC<BillingProps> = ({
 
       setCurrentlySelectedSubscriptionPlan(selectedSubscriptionPlan)
     }
-  }
-
-  const handleDialogClose = () => {
-    setDialogOpen(false)
-
-    // defer clear
-    setTimeout(() => {
-      clearSubscriptionInfoAction()
-    }, 500)
   }
 
   const [

--- a/lib/pages/Billing/Billing.tsx
+++ b/lib/pages/Billing/Billing.tsx
@@ -30,7 +30,7 @@ const Billing: React.FC<BillingProps> = ({
   const trans = useTranslation()
   const [dialogOpen, setDialogOpen] = useState(false)
 
-  const t = (str: string) => {
+  const t = (str: string, ...args) => {
     return trans.t(`extensions.billing.${str}`)
   }
 
@@ -369,7 +369,10 @@ const Billing: React.FC<BillingProps> = ({
         open={wantsToChangeSubscriptionPlan}
         onClose={handleWantsToChangeSubscriptionPlan}
         title={t('changeSubscriptionDialog.title')}
-        text={t('changeSubscriptionDialog.text')}
+        text={t('changeSubscriptionDialog.text', {
+          newlySelectedSubscriptionPlan:
+            currentlySelectedSubscriptionPlan.nameOfSubscriptionPlan,
+        })}
         subText={t('changeSubscriptionDialog.subText')}
         actions={[
           <Button

--- a/lib/pages/Billing/Billing.tsx
+++ b/lib/pages/Billing/Billing.tsx
@@ -30,8 +30,8 @@ const Billing: React.FC<BillingProps> = ({
   const trans = useTranslation()
   const [dialogOpen, setDialogOpen] = useState(false)
 
-  const t = (str: string, ...args) => {
-    return trans.t(`extensions.billing.${str}`)
+  const t = (str: string, otherParameters?) => {
+    return trans.t(`extensions.billing.${str}`, otherParameters)
   }
 
   /* Triggers the retrieval and storage (on the app's Store, under 'billing')

--- a/lib/pages/Billing/Billing.tsx
+++ b/lib/pages/Billing/Billing.tsx
@@ -27,8 +27,8 @@ const Billing: React.FC<BillingProps> = ({
   user,
 }) => {
   const classes = useStyles()
-
   const trans = useTranslation()
+  const [dialogOpen, setDialogOpen] = useState(false)
 
   const t = (str: string, ...args) => {
     return trans.t(`extensions.billing.${str}`, ...args)
@@ -43,6 +43,12 @@ const Billing: React.FC<BillingProps> = ({
     getAllUserDetailsAction(user.id)
     getAllUserTransactionsAction()
   }, [successfullySubscribedToPlan])
+
+  useEffect(() => {
+    if (dialogInfo.transKeys.title.length) {
+      setDialogOpen(true)
+    }
+  }, [dialogInfo.transKeys.title])
 
   /* Credits logic */
 
@@ -137,6 +143,15 @@ const Billing: React.FC<BillingProps> = ({
 
       setCurrentlySelectedSubscriptionPlan(selectedSubscriptionPlan)
     }
+  }
+
+  const handleDialogClose = () => {
+    setDialogOpen(false)
+
+    // defer clear
+    setTimeout(() => {
+      clearSubscriptionInfoAction()
+    }, 500)
   }
 
   const [
@@ -348,6 +363,24 @@ const Billing: React.FC<BillingProps> = ({
           </>
         )}
       </main>
+
+      <CustomizableDialog
+        open={dialogOpen}
+        onClose={handleDialogClose}
+        icon={dialogInfo.type}
+        title={t(dialogInfo.transKeys.title)}
+        text={t(dialogInfo.transKeys.text)}
+        subText={t(dialogInfo.transKeys.subText)}
+        actions={[
+          <Button
+            key="cancel-sub-confirm"
+            variant="outlined"
+            onClick={handleDialogClose}
+          >
+            {t('closeCTA')}
+          </Button>,
+        ]}
+      />
 
       <CustomizableDialog
         icon="warning"

--- a/lib/pages/Billing/Billing.tsx
+++ b/lib/pages/Billing/Billing.tsx
@@ -369,10 +369,7 @@ const Billing: React.FC<BillingProps> = ({
         open={wantsToChangeSubscriptionPlan}
         onClose={handleWantsToChangeSubscriptionPlan}
         title={t('changeSubscriptionDialog.title')}
-        text={t('changeSubscriptionDialog.text', {
-          newSubscriptionPlan:
-            currentlySelectedSubscriptionPlan.nameOfSubscriptionPlan,
-        })}
+        text={t('changeSubscriptionDialog.text')}
         subText={t('changeSubscriptionDialog.subText')}
         actions={[
           <Button

--- a/lib/pages/TransactionComplete/TransactionComplete.tsx
+++ b/lib/pages/TransactionComplete/TransactionComplete.tsx
@@ -4,6 +4,8 @@ import { useTranslation } from '@apisuite/fe-base'
 import { TransactionCompleteProps } from './types'
 import Link from '../../components/Link'
 import useStyles from './styles'
+import { convertDate } from '../../util/convertDate'
+import { currencyConverter } from '../../util/currencyConverter'
 
 const TransactionComplete: React.FC<TransactionCompleteProps> = ({
   getTransactionDetailsAction,
@@ -23,26 +25,6 @@ const TransactionComplete: React.FC<TransactionCompleteProps> = ({
 
     getTransactionDetailsAction(idOfTransaction)
   }, [])
-
-  const convertDate = (dateString: string) => {
-    console.log('dateString', dateString)
-    const dateFormat = new Intl.DateTimeFormat(trans.i18n.language, {
-      year: 'numeric',
-      month: 'long',
-      day: '2-digit',
-      hour: '2-digit',
-      minute: '2-digit',
-    })
-
-    return dateFormat.format(new Date(dateString))
-  }
-
-  const currencyConverter = (valueString: string, currencyString: string) => {
-    return parseInt(valueString).toLocaleString(trans.i18n.language, {
-      style: 'currency',
-      currency: currencyString,
-    })
-  }
 
   return (
     <main className={`page-container ${classes.pageContentContainer}`}>
@@ -95,6 +77,7 @@ const TransactionComplete: React.FC<TransactionCompleteProps> = ({
             {transactionDetails.transactionAmount.transactionValue &&
               transactionDetails.transactionAmount.transactionCurrency &&
               currencyConverter(
+                trans.i18n.language,
                 transactionDetails.transactionAmount.transactionValue,
                 transactionDetails.transactionAmount.transactionCurrency
               )}
@@ -112,7 +95,10 @@ const TransactionComplete: React.FC<TransactionCompleteProps> = ({
 
           <p>
             {transactionDetails.transactionDate &&
-              convertDate(transactionDetails.transactionDate)}
+              convertDate(
+                trans.i18n.language,
+                transactionDetails.transactionDate
+              )}
           </p>
         </div>
       </div>

--- a/lib/pages/TransactionComplete/TransactionComplete.tsx
+++ b/lib/pages/TransactionComplete/TransactionComplete.tsx
@@ -25,16 +25,24 @@ const TransactionComplete: React.FC<TransactionCompleteProps> = ({
   }, [])
 
   const convertDate = (dateString: string) => {
+    console.log('dateString', dateString)
     const dateFormat = new Intl.DateTimeFormat(trans.i18n.language, {
       year: 'numeric',
       month: 'long',
       day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
     })
 
     return dateFormat.format(new Date(dateString))
   }
 
-  // TODO: Convert 'EUR' references to '€'
+  const currencyConverter = (valueString: string, currencyString: string) => {
+    return parseInt(valueString).toLocaleString(trans.i18n.language, {
+      style: 'currency',
+      currency: currencyString,
+    })
+  }
 
   return (
     <main className={`page-container ${classes.pageContentContainer}`}>
@@ -84,8 +92,12 @@ const TransactionComplete: React.FC<TransactionCompleteProps> = ({
           <p>{t('transactionComplete.transactionDetails.price')}</p>
 
           <p>
-            {`${transactionDetails.transactionAmount.transactionCurrency}
-${transactionDetails.transactionAmount.transactionValue}`}
+            {transactionDetails.transactionAmount.transactionValue &&
+              transactionDetails.transactionAmount.transactionCurrency &&
+              currencyConverter(
+                transactionDetails.transactionAmount.transactionValue,
+                transactionDetails.transactionAmount.transactionCurrency
+              )}
           </p>
         </div>
 
@@ -98,7 +110,10 @@ ${transactionDetails.transactionAmount.transactionValue}`}
         <div className={classes.transactionDetailContainer}>
           <p>{t('transactionComplete.transactionDetails.transactionDate')}</p>
 
-          <p>{convertDate(transactionDetails.transactionDate)}</p>
+          <p>
+            {transactionDetails.transactionDate &&
+              convertDate(transactionDetails.transactionDate)}
+          </p>
         </div>
       </div>
     </main>

--- a/lib/translations/en-US.json
+++ b/lib/translations/en-US.json
@@ -25,7 +25,7 @@
       },
       "changeSubscriptionDialog": {
         "title": "Change subscription plan",
-        "text": "Are you sure you want to change your subscription?",
+        "text": "Are you sure you want to change your subscription to {{newlySelectedSubscriptionPlan}}?",
         "subText": "Once you click on \"Start new subscription\" button, your current plan will be automatically canceled, and you will be redirected to the payment page for your new subscription.",
         "cancelButtonLabel": "Cancel",
         "confirmButtonLabel": "Start new subscription"

--- a/lib/util/convertDate.ts
+++ b/lib/util/convertDate.ts
@@ -1,0 +1,9 @@
+export const convertDate = (languageString: string, dateString: string) => {
+  const dateFormat = new Intl.DateTimeFormat(languageString, {
+    year: 'numeric',
+    month: 'long',
+    day: '2-digit',
+  })
+
+  return dateFormat.format(new Date(dateString))
+}

--- a/lib/util/currencyConverter.ts
+++ b/lib/util/currencyConverter.ts
@@ -1,0 +1,10 @@
+export const currencyConverter = (
+  languageString: string,
+  valueString: string,
+  currencyString: string
+) => {
+  return parseInt(valueString).toLocaleString(languageString, {
+    style: 'currency',
+    currency: currencyString,
+  })
+}


### PR DESCRIPTION
Added a small function that converts all references to a currency to its associated symbol (if any).

For this function be used in other places of the Billing extension, our API will have to provide a designation such as USD, EUR, YEN, etc., to everything that has a cost (credit packs, and subscription plans).

The "complete transactions" view, and the "transactions table" already use this function.