### PR TITLE
feat: Added support for 'Terms of Service' warning on Billing's subscription change dialog

### DIFF
--- a/lib/pages/Billing/Billing.tsx
+++ b/lib/pages/Billing/Billing.tsx
@@ -15,7 +15,6 @@ import SubscriptionsTable from '../../components/SubscriptionsTable'
 import TransactionsTable from '../../components/TransactionsTable'
 import { BillingProps } from './types'
 import useStyles from './styles'
-import config from '../../helpers/config'
 import Link from '../../components/Link'
 
 const Billing: React.FC<BillingProps> = ({
@@ -262,32 +261,36 @@ const Billing: React.FC<BillingProps> = ({
   }, [successfullySubscribedToPlan])
 
   const generateWarning = () => {
+    const replacementTagsArray = []
+
+    {
+      /* The '...changeSubscriptionDialog.warning.text' translation includes a replacement tag (<0>...</0>).
+      If a '...changeSubscriptionDialog.warning.url' translation exists and is not empty, this tag will be
+      replaced by a <Link> tag, otherwise, no replacement takes place and the translation is rendered normally.
+      */
+    }
+    if (t('changeSubscriptionDialog.warning.url')) {
+      replacementTagsArray.push(
+        <Link
+          style={{
+            color: palette.info.main,
+            fontWeight: 400,
+          }}
+          key="warningUrl"
+          rel="noopener noreferrer"
+          target="_blank"
+          to={t('changeSubscriptionDialog.warning.url')}
+        />
+      )
+    }
+
     return (
       <Typography
         style={{ color: palette.text.primary, fontWeight: 300 }}
         variant="body2"
       >
-        {/* The following translation includes a replacement tag (<0>...</0>).
-            This tag will be replaced by a <Link> tag if a URL for our warning is provided,
-            or by an empty tag otherwise.
-        */}
         <Trans i18nKey="changeSubscriptionDialog.warning.text" t={t}>
-          {[
-            t('changeSubscriptionDialog.warning.url') ? (
-              <Link
-                style={{
-                  color: palette.info.main,
-                  fontWeight: 400,
-                }}
-                key="warningUrl"
-                rel="noopener noreferrer"
-                target="_blank"
-                to={t('changeSubscriptionDialog.warning.url')}
-              />
-            ) : (
-              <></>
-            ),
-          ]}
+          {replacementTagsArray}
         </Trans>
       </Typography>
     )

--- a/lib/pages/Billing/Billing.tsx
+++ b/lib/pages/Billing/Billing.tsx
@@ -263,12 +263,10 @@ const Billing: React.FC<BillingProps> = ({
   const generateWarning = () => {
     const replacementTagsArray = []
 
-    {
-      /* The '...changeSubscriptionDialog.warning.text' translation includes a replacement tag (<0>...</0>).
-      If a '...changeSubscriptionDialog.warning.url' translation exists and is not empty, this tag will be
-      replaced by a <Link> tag, otherwise, no replacement takes place and the translation is rendered normally.
-      */
-    }
+    /* The '...changeSubscriptionDialog.warning.text' translation includes a replacement tag (<0>...</0>).
+    If a '...changeSubscriptionDialog.warning.url' translation exists and is not empty, this tag will be
+    replaced by a <Link> tag, otherwise, no replacement takes place and the translation is rendered normally.
+    */
     if (t('changeSubscriptionDialog.warning.url')) {
       replacementTagsArray.push(
         <Link

--- a/lib/pages/Billing/Billing.tsx
+++ b/lib/pages/Billing/Billing.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import {
   Box,
   Button,
+  Trans,
   Typography,
   useTheme,
   useTranslation,
@@ -14,6 +15,8 @@ import SubscriptionsTable from '../../components/SubscriptionsTable'
 import TransactionsTable from '../../components/TransactionsTable'
 import { BillingProps } from './types'
 import useStyles from './styles'
+import config from '../../helpers/config'
+import Link from '../../components/Link'
 
 const Billing: React.FC<BillingProps> = ({
   allCreditPacks,
@@ -258,6 +261,38 @@ const Billing: React.FC<BillingProps> = ({
     }
   }, [successfullySubscribedToPlan])
 
+  const generateWarning = () => {
+    return (
+      <Typography
+        style={{ color: palette.text.primary, fontWeight: 300 }}
+        variant="body2"
+      >
+        {/* The following translation includes a replacement tag (<0>...</0>).
+            This tag will be replaced by a <Link> tag if a URL for our warning is provided,
+            or by an empty tag otherwise.
+        */}
+        <Trans i18nKey="changeSubscriptionDialog.warning.text" t={t}>
+          {[
+            t('changeSubscriptionDialog.warning.url') ? (
+              <Link
+                style={{
+                  color: palette.info.main,
+                  fontWeight: 400,
+                }}
+                key="warningUrl"
+                rel="noopener noreferrer"
+                target="_blank"
+                to={t('changeSubscriptionDialog.warning.url')}
+              />
+            ) : (
+              <></>
+            ),
+          ]}
+        </Trans>
+      </Typography>
+    )
+  }
+
   return (
     <>
       <main className={`page-container ${classes.billingContentContainer}`}>
@@ -485,7 +520,9 @@ const Billing: React.FC<BillingProps> = ({
             {t('changeSubscriptionDialog.confirmButtonLabel')}
           </Button>,
         ]}
-      />
+      >
+        {generateWarning()}
+      </CustomizableDialog>
     </>
   )
 }

--- a/lib/translations/en-US.json
+++ b/lib/translations/en-US.json
@@ -32,7 +32,7 @@
         "cancelButtonLabel": "Cancel",
         "confirmButtonLabel": "Start new subscription",
         "warning": {
-          "url": "https://www.google.com",
+          "url": "https://cloudoki.atlassian.net/wiki/spaces/APIEC/pages/774111233/Terms+of+Service",
           "text": "By starting a new subscription, you hereby agree to our <0>Terms of Service</0>."
         }
       },

--- a/lib/translations/en-US.json
+++ b/lib/translations/en-US.json
@@ -30,7 +30,11 @@
         "text": "Are you sure you want to change your subscription to {{newlySelectedSubscriptionPlan}}?",
         "subText": "By starting a new subscription, your current plan will be automatically canceled. The new plan's cost will be charged using your selected payment method and, if no longer valid, you will be directed to a new payment page.",
         "cancelButtonLabel": "Cancel",
-        "confirmButtonLabel": "Start new subscription"
+        "confirmButtonLabel": "Start new subscription",
+        "warning": {
+          "url": "https://google.com",
+          "text": "By starting a new subscription, you also hereby agree to our <0>Terms of Service</0>."
+        }
       },
       "subscriptionsTable": {
         "title": "Subscription",

--- a/lib/translations/en-US.json
+++ b/lib/translations/en-US.json
@@ -32,8 +32,8 @@
         "cancelButtonLabel": "Cancel",
         "confirmButtonLabel": "Start new subscription",
         "warning": {
-          "url": "https://google.com",
-          "text": "By starting a new subscription, you also hereby agree to our <0>Terms of Service</0>."
+          "url": "https://www.google.com",
+          "text": "By starting a new subscription, you hereby agree to our <0>Terms of Service</0>."
         }
       },
       "subscriptionsTable": {


### PR DESCRIPTION
Explored several ways of going about this task - https://cloudoki.atlassian.net/browse/APXB-47 - but ultimately came to find this solution as the simplest one. Could potentially be turned into a utility function, to be used in other places, but would need to confirm this belief.

Essentially, the function looks at a translation string, and replaces its tags with a Link component (if a URL translation is provided), or an empty element (making it either a link or just some plain text, respectively).