### PR TITLE
Update of documentation for setting warning when changing subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ These are used to replace these tags with some others to e.g., turn some transla
 
 Translations keys where this is available:
 
-- `extensions.billing.changeSubscriptionDialog.warning`:
-  - `extensions.billing.changeSubscriptionDialog.warning.text`: Placeholder text where a replacement tag can be inserted;
-  - `extensions.billing.changeSubscriptionDialog.warning.url`: URL to replace in `warning.text`
+- `extensions.billing.dialogToSWarning`:
+  - `extensions.billing.dialogToSWarning.text`: Placeholder text where a replacement tag can be inserted;
+  - `extensions.billing.dialogToSWarning.url`: URL to replace in `warning.text`
 


### PR DESCRIPTION
Since the last release of the billing ui extension, the documentation in the README.md file was not up to date. Fixed the documentation to represent the correct translation fields.