### PR TITLE
feat - show different warning message based on billing type

### DIFF
--- a/build/pages/Billing/Billing.js
+++ b/build/pages/Billing/Billing.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Box, Button, Icon, CircularProgress, TextField, Trans, Typography, useTheme, useTranslation, } from '@apisuite/fe-base';
+import { Box, Button, CircularProgress, Icon, TextField, Trans, Typography, useTheme, useTranslation, } from '@apisuite/fe-base';
 import { CustomizableDialog } from '../../components/CustomizableDialog/CustomizableDialog';
 import CreditPacksCatalog from '../../components/CreditPacksCatalog/CreditPacksCatalog';
 import SubscriptionsCatalog from '../../components/SubscriptionsCatalog';
@@ -176,19 +176,19 @@ const Billing = ({ cancelSubscriptionAction, clearSubscriptionInfoAction, credit
             setDialogOpen(true);
         }
     }, [dialogInfo.transKeys.title]);
-    const generateWarning = () => {
+    const generateWarning = (type) => {
         const replacementTagsArray = [];
         /* The 'dialogToSWarning.text' translation includes a replacement tag (<0></0>).
         If a 'dialogToSWarning.url' translation exists and is not empty, this will be
         replaced by a <Link> tag, otherwise, no replacement takes place and the translation is rendered normally. */
-        if (t('dialogToSWarning.url')) {
+        if (t(`dialogToSWarning.${type}.url`)) {
             replacementTagsArray.push(React.createElement(Link, { style: {
                     color: palette.info.main,
                     fontWeight: 400,
-                }, key: "warningUrl", rel: "noopener noreferrer", target: "_blank", to: t('dialogToSWarning.url') }));
+                }, key: "warningUrl", rel: "noopener noreferrer", target: "_blank", to: t(`dialogToSWarning.${type}.url`) }));
         }
         return (React.createElement(Typography, { style: { color: palette.text.primary, fontWeight: 300 }, variant: "body2" },
-            React.createElement(Trans, { i18nKey: "dialogToSWarning.text", t: t }, replacementTagsArray)));
+            React.createElement(Trans, { i18nKey: `dialogToSWarning.${type}.text`, t: t }, replacementTagsArray)));
     };
     return (React.createElement(React.Fragment, null,
         React.createElement("main", { className: `page-container ${classes.billingContentContainer}` },
@@ -278,7 +278,7 @@ const Billing = ({ cancelSubscriptionAction, clearSubscriptionInfoAction, credit
                     } }, t('confirmCreditTopUpDialog.confirmButtonLabel')),
             ], icon: "warning", onClose: handleOpenTopUpDialog, open: openTopUpDialog, subText: t('confirmCreditTopUpDialog.subText'), text: t('confirmCreditTopUpDialog.text', {
                 creditAmount: selectedCreditPack.credits,
-            }), title: t('confirmCreditTopUpDialog.title') }, generateWarning()),
+            }), title: t('confirmCreditTopUpDialog.title') }, generateWarning('topup')),
         React.createElement(CustomizableDialog, { actions: [
                 React.createElement(Button, { key: "cancelSubscriptionPlanStart", onClick: handleWantsToStartSubscriptionPlan, variant: "outlined" }, t('startSubscriptionDialog.cancelButtonLabel')),
                 React.createElement(Button, { className: classes.dialogConfirmButton, key: "confirmSubscriptionPlanStart", onClick: () => {
@@ -286,7 +286,7 @@ const Billing = ({ cancelSubscriptionAction, clearSubscriptionInfoAction, credit
                     } }, t('startSubscriptionDialog.confirmButtonLabel')),
             ], icon: "warning", onClose: handleWantsToStartSubscriptionPlan, open: wantsToStartSubscriptionPlan, subText: t('startSubscriptionDialog.subText'), text: t('startSubscriptionDialog.text', {
                 selectedSubscriptionPlan: selectedSubscriptionPlan.name,
-            }), title: t('startSubscriptionDialog.title') }, generateWarning()),
+            }), title: t('startSubscriptionDialog.title') }, generateWarning('subscription')),
         React.createElement(CustomizableDialog, { actions: [
                 React.createElement(Button, { key: "cancel-sub-confirm", onClick: handleDialogClose, variant: "outlined" }, t('closeCTA')),
             ], icon: dialogInfo.type, onClose: handleDialogClose, open: dialogOpen, subText: t(dialogInfo.transKeys.subText), text: t(dialogInfo.transKeys.text), title: t(dialogInfo.transKeys.title) }),
@@ -297,6 +297,6 @@ const Billing = ({ cancelSubscriptionAction, clearSubscriptionInfoAction, credit
                     } }, t('changeSubscriptionDialog.confirmButtonLabel')),
             ], icon: "warning", onClose: handleWantsToChangeSubscriptionPlan, open: wantsToChangeSubscriptionPlan, subText: t('changeSubscriptionDialog.subText'), text: t('changeSubscriptionDialog.text', {
                 newlySelectedSubscriptionPlan: selectedSubscriptionPlan.name,
-            }), title: t('changeSubscriptionDialog.title') }, generateWarning())));
+            }), title: t('changeSubscriptionDialog.title') }, generateWarning('subscription'))));
 };
 export default Billing;

--- a/build/translations/en-US.json
+++ b/build/translations/en-US.json
@@ -49,8 +49,14 @@
                 "confirmButtonLabel": "Start new subscription"
             },
             "dialogToSWarning": {
-                "url": "",
-                "text": ""
+                "topup": {
+                    "url": "",
+                    "text": "Dit is een test voor popups"
+                },
+                "subscription": {
+                    "url": "",
+                    "text": "Dit is een test voor subscriptions"
+                }
             },
             "subscriptionsTable": {
                 "title": "Subscription",

--- a/lib/pages/Billing/Billing.tsx
+++ b/lib/pages/Billing/Billing.tsx
@@ -2,8 +2,8 @@ import React, { useEffect, useState } from 'react'
 import {
   Box,
   Button,
-  Icon,
   CircularProgress,
+  Icon,
   TextField,
   Trans,
   Typography,
@@ -297,13 +297,13 @@ const Billing: React.FC<BillingProps> = ({
     }
   }, [dialogInfo.transKeys.title])
 
-  const generateWarning = () => {
+  const generateWarning = (type) => {
     const replacementTagsArray = []
 
     /* The 'dialogToSWarning.text' translation includes a replacement tag (<0></0>).
     If a 'dialogToSWarning.url' translation exists and is not empty, this will be
     replaced by a <Link> tag, otherwise, no replacement takes place and the translation is rendered normally. */
-    if (t('dialogToSWarning.url')) {
+    if (t(`dialogToSWarning.${type}.url`)) {
       replacementTagsArray.push(
         <Link
           style={{
@@ -313,17 +313,16 @@ const Billing: React.FC<BillingProps> = ({
           key="warningUrl"
           rel="noopener noreferrer"
           target="_blank"
-          to={t('dialogToSWarning.url')}
+          to={t(`dialogToSWarning.${type}.url`)}
         />
       )
     }
-
     return (
       <Typography
         style={{ color: palette.text.primary, fontWeight: 300 }}
         variant="body2"
       >
-        <Trans i18nKey="dialogToSWarning.text" t={t}>
+        <Trans i18nKey={`dialogToSWarning.${type}.text`} t={t}>
           {replacementTagsArray}
         </Trans>
       </Typography>
@@ -697,7 +696,7 @@ const Billing: React.FC<BillingProps> = ({
         })}
         title={t('confirmCreditTopUpDialog.title')}
       >
-        {generateWarning()}
+        {generateWarning('topup')}
       </CustomizableDialog>
 
       {/* Subscription-related dialogs */}
@@ -729,7 +728,7 @@ const Billing: React.FC<BillingProps> = ({
         })}
         title={t('startSubscriptionDialog.title')}
       >
-        {generateWarning()}
+        {generateWarning('subscription')}
       </CustomizableDialog>
 
       <CustomizableDialog
@@ -779,7 +778,7 @@ const Billing: React.FC<BillingProps> = ({
         })}
         title={t('changeSubscriptionDialog.title')}
       >
-        {generateWarning()}
+        {generateWarning('subscription')}
       </CustomizableDialog>
     </>
   )

--- a/lib/translations/en-US.json
+++ b/lib/translations/en-US.json
@@ -49,8 +49,14 @@
         "confirmButtonLabel": "Start new subscription"
       },
       "dialogToSWarning": {
-        "url": "",
-        "text": ""
+        "topup": {
+          "url": "",
+          "text": "Dit is een test voor popups"
+        },
+        "subscription": {
+          "url": "",
+          "text": "Dit is een test voor subscriptions"
+        }
       },
       "subscriptionsTable": {
         "title": "Subscription",
@@ -108,10 +114,10 @@
         "invoiceSavingError": "An error saving your invoice note occurred."
       },
       "transactioncard": {
-        "reference" : "Reference",
-        "price" : "Price",
-        "creditAmount" : "Credit amount",
-        "purchaseDate" : "Date of purchase"
+        "reference": "Reference",
+        "price": "Price",
+        "creditAmount": "Credit amount",
+        "purchaseDate": "Date of purchase"
       },
       "editPaymentConfirm": {
         "title": "You have edited your payment method!",

--- a/lib/translations/en-US.json
+++ b/lib/translations/en-US.json
@@ -51,11 +51,11 @@
       "dialogToSWarning": {
         "topup": {
           "url": "",
-          "text": "Dit is een test voor popups"
+          "text": ""
         },
         "subscription": {
           "url": "",
-          "text": "Dit is een test voor subscriptions"
+          "text": ""
         }
       },
       "subscriptionsTable": {


### PR DESCRIPTION
When a user selects to do a payment through a top-up or start/change a subscription, they get a confirmation dialog before being redirected to payment gateway. One important component of this dialog is the warning message to direct the user to the terms and conditions. However, this warning message is common for all billing methods. In the case of a top-up, the warning shows information about the subscriptions:

![image](https://user-images.githubusercontent.com/10883374/148344705-5531b870-f768-418f-9d6d-08941262a78f.png)

The feature proposed in this pull request is to make the text depending on the billing method. This would allow administrators of the marketplace to set a different warning text for top-ups and subscriptions. Furthermore, if a warning message is not required for one of the methods (for example topups), the text can be hidden through the translations.