### PR TITLE
fix - added rounding to 2 numbers of the pricing in the UI

### DIFF
--- a/build/components/CreditPacksCatalog/CreditPacksCatalog.js
+++ b/build/components/CreditPacksCatalog/CreditPacksCatalog.js
@@ -16,7 +16,7 @@ const CreditPacksCatalog = ({ creditPacks, selectedCreditPack, handleCreditPackS
                     React.createElement(Typography, { variant: "body1", color: "inherit" },
                         React.createElement("b", null,
                             "\u20AC ",
-                            creditPack.price)),
+                            creditPack.price.toFixed(2))),
                     React.createElement(Typography, { variant: "body2", color: "inherit" },
                         creditPack.credits,
                         " Cr"))));

--- a/build/components/SubscriptionsCatalog/SubscriptionsCatalog.js
+++ b/build/components/SubscriptionsCatalog/SubscriptionsCatalog.js
@@ -27,7 +27,7 @@ const SubscriptionsCatalog = ({ activeSubscriptionID, subscriptions, selectedSub
                         React.createElement(Typography, { variant: "body1" },
                             React.createElement("b", null,
                                 "\u20AC ",
-                                sub.price)),
+                                sub.price.toFixed(2))),
                         React.createElement(Typography, { variant: "body2" }, sub.periodicity))),
                 sub.id === activeSubscriptionID && (React.createElement("div", { className: classes.disabledSubscriptionContainer, onClick: (event) => {
                         event.stopPropagation();

--- a/lib/components/CreditPacksCatalog/CreditPacksCatalog.tsx
+++ b/lib/components/CreditPacksCatalog/CreditPacksCatalog.tsx
@@ -38,7 +38,7 @@ const CreditPacksCatalog: React.FC<CreditPacksCatalogProps> = ({
 
           <Box color={palette.text.primary}>
             <Typography variant="body1" color="inherit">
-              <b>€ {creditPack.price}</b>
+              <b>€ {creditPack.price.toFixed(2)}</b>
             </Typography>
 
             <Typography variant="body2" color="inherit">

--- a/lib/components/SubscriptionsCatalog/SubscriptionsCatalog.tsx
+++ b/lib/components/SubscriptionsCatalog/SubscriptionsCatalog.tsx
@@ -53,7 +53,7 @@ const SubscriptionsCatalog: React.FC<SubscriptionsCatalogProps> = ({
 
             <div>
               <Typography variant="body1">
-                <b>€ {sub.price}</b>
+                <b>€ {sub.price.toFixed(2)}</b>
               </Typography>
 
               <Typography variant="body2">{sub.periodicity}</Typography>


### PR DESCRIPTION
When specifying the  packages and subscription plans in the billing backend, a specific VAT rate (in this case 21%) is applied by default. By applying this rate, prices can have more than 2 digits behind the decimal point which are also visible in the user interface. It does not make any sense to put any more digits than 2 when communicating prices. 

![image](https://user-images.githubusercontent.com/10883374/148553670-267dc9da-8a76-4cf8-a632-03b5a4a0290a.png)


In this PR, changes to the code have been made to make sure all pricing information is limited to 2 decimals.